### PR TITLE
Bring repo tooling and docs in line with miele-outlet-scrape conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/ruff-action@v3
+
+  markdownlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: DavidAnson/markdownlint-cli2-action@v24
+        with:
+          config: .markdownlint.jsonc
+          globs: |
+            **/*.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.py"
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - ".github/workflows/test.yml"
+  pull_request:
+    paths:
+      - "**.py"
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - ".github/workflows/test.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: requirements*.txt
+      - run: pip install -r requirements-dev.txt
+      # now-playing.py has a hyphen so it can't be `--cov`'d by module name
+      # (`now_playing`); --cov=. tracks by path instead (see pyproject.toml
+      # [tool.coverage.run] for the omit config that scopes the report).
+      - run: python3 -m pytest --cov=. --cov-report=term-missing --cov-report=xml
+      - uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.claude/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.coverage
+coverage.xml

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "MD013": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# AGENTS.md
+
+## What this is
+
+A single iTerm2 status-bar script (`now-playing.py`) that shows the
+currently-playing Spotify track. It runs inside iTerm2's own Python Runtime
+(not a normal interpreter) and shells out to `osascript` to ask Spotify, via
+AppleScript, what's currently playing. There is no CLI, no packaging, and no
+inline PEP 723 metadata -- it's installed by symlinking the file into
+iTerm2's AutoLaunch folder (see README.md).
+
+## Commands
+
+### Setup
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+```
+
+There is no `requirements.txt` for `now-playing.py` itself: its only
+non-stdlib import, `iterm2`, is bundled with iTerm2's Python Runtime and is
+**not on PyPI**. Do not try to `pip install iterm2` locally or in CI -- it
+will fail (or silently install an unrelated package).
+
+### Test
+
+```sh
+python3 -m pytest
+```
+
+### Lint
+
+```sh
+ruff check .
+```
+
+## Structure
+
+- `now-playing.py` -- the entire status-bar component: `applescript` (the
+  template string sent to `osascript`), `check_spotify()` (runs it and
+  parses the result), and `main()`/`coro` (the `iterm2` status-bar
+  registration and formatting logic).
+- `tests/test_now_playing.py` -- unit tests for `check_spotify()` only.
+- `img/` -- screenshots used in README.md.
+
+## Conventions
+
+- `iterm2` can only be imported/run inside iTerm2's bundled Python Runtime.
+  It is not installable via pip, so CI never attempts it -- the test suite
+  stubs it out in `sys.modules` before loading the script (see
+  `tests/test_now_playing.py`). Never add `iterm2` to a requirements file.
+- The AppleScript in `applescript` is fragile, string-templated shell
+  content that emits semicolon-delimited fields (`state;name;artist;percent`
+  or `closed;;;`). If you change its output shape, you must update
+  `check_spotify()`'s parsing (the `.split(";")` and index-based lookups)
+  and the `coro` formatting strings (`"{0} {1} - {2} ({3}%)"` etc.) in the
+  same change, or the status bar will silently show garbage.
+- `check_spotify()` is the only synchronous, `iterm2`-independent logic, and
+  therefore the only thing unit-tested. `main()`/`coro`/the
+  `iterm2.StatusBarComponent` registration require a real iTerm2 process and
+  can't be meaningfully unit tested -- they're only verified by manual
+  end-to-end testing (see CONTRIBUTING.md).
+- Manual/E2E testing requires symlinking the script into
+  `~/Library/Application Support/iTerm2/Scripts/AutoLaunch/` (per README.md)
+  and restarting iTerm2, ideally with Spotify open in each of the
+  playing/paused/closed states.
+- No type hints are currently used in `now-playing.py`. Match the existing
+  (untyped) style if you edit it; if you do add type hints, do so
+  consistently across the whole file rather than partially.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This project's agent instructions live in [`AGENTS.md`](./AGENTS.md); this file just imports it so Claude Code picks it up automatically (Claude Code reads `CLAUDE.md`, not `AGENTS.md`, directly).
+
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+## Development setup
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+```
+
+Note: `now-playing.py`'s own runtime dependency, `iterm2`, is bundled with
+iTerm2's Python Runtime and is not available on PyPI, so it isn't (and can't
+be) listed in a requirements file. The dev setup above only installs test
+tooling.
+
+## Running tests
+
+```sh
+python3 -m pytest
+```
+
+Tests cover `check_spotify()` by mocking `subprocess.Popen`. Manual
+end-to-end testing of the status-bar component itself (the `iterm2`
+registration, live formatting, refresh cadence, etc.) requires an actual
+iTerm2 + Spotify installation, since the `iterm2` runtime and Spotify's
+AppleScript integration can't be exercised in CI. To test manually, symlink
+the script into iTerm2's AutoLaunch folder as described in the README and
+restart iTerm2.
+
+## Linting
+
+This project uses [ruff](https://docs.astral.sh/ruff/) for Python linting and
+[markdownlint](https://github.com/DavidAnson/markdownlint) for Markdown files.
+
+```sh
+ruff check .
+```
+
+## Pull requests
+
+- Keep changes focused and add tests for new behaviour.
+- Make sure `ruff check .` and `python3 -m pytest` both pass before opening a PR.
+- CI runs both automatically on every push and pull request.
+
+## Future improvements
+
+Ideas not yet implemented, kept here for reference:
+
+- Customisable refresh interval.
+- Improved error handling(?).
+- Investigate replacement of calling `osascript` to get track information.
+- Scrolling text.
+- Click to open Spotify.
+- Add track to saved songs.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,12 @@
 # Spotify Track Info for iTerm2 Status Bar
 
+[![Lint](https://github.com/jackrayner/iterm2-spotify-nowplaying/actions/workflows/lint.yml/badge.svg)](https://github.com/jackrayner/iterm2-spotify-nowplaying/actions/workflows/lint.yml)
+[![Test](https://github.com/jackrayner/iterm2-spotify-nowplaying/actions/workflows/test.yml/badge.svg)](https://github.com/jackrayner/iterm2-spotify-nowplaying/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 _Enables Spotify track information in the iTerm2 status bar._
 
 ![Main Window](/img/main_window.png "Main Window")
-
-## Prerequisites
-
-- iTerm2
-- iTerm2 Python Runtime (Will be installed on first launch after installation)
-
-## Installation
-
-```
-git clone https://github.com/jackrayner/iterm2-spotify-nowplaying.git
-cd iterm2-spotify-nowplaying
-mkdir -p ~/Library/Application\ Support/iTerm2/Scripts/AutoLaunch
-ln -s "${PWD}/now-playing.py" ~/Library/Application\ Support/iTerm2/Scripts/AutoLaunch/now-playing.py
-```
 
 ## Features
 
@@ -34,12 +24,25 @@ ln -s "${PWD}/now-playing.py" ~/Library/Application\ Support/iTerm2/Scripts/Auto
   - ![Status Bar](/img/reduced_2.png "Status Bar")
   - ![Status Bar](/img/reduced_3.png "Status Bar")
 
-## TODO - Future improvements
+## Requirements
 
-- Customisable refresh interval.
-- Improved error handling(?).
-- Investigate replacement of calling `osascript` to get track information.
-- Travis CI testing.
-- Scrolling text.
-- Click to open Spotify.
-- Add track to saved songs.
+- iTerm2
+- iTerm2 Python Runtime (will be installed on first launch after installation)
+
+## Installation
+
+```sh
+git clone https://github.com/jackrayner/iterm2-spotify-nowplaying.git
+cd iterm2-spotify-nowplaying
+mkdir -p ~/Library/Application\ Support/iTerm2/Scripts/AutoLaunch
+ln -s "${PWD}/now-playing.py" ~/Library/Application\ Support/iTerm2/Scripts/AutoLaunch/now-playing.py
+```
+
+## Development
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, running tests,
+linting, and a list of planned future improvements.
+
+## License
+
+[MIT](LICENSE)

--- a/now-playing.py
+++ b/now-playing.py
@@ -3,8 +3,9 @@
 # MIT License
 # Copyright (c) 2020 Jack Rayner <me@jrayner.net>
 
+from subprocess import PIPE, Popen
+
 import iterm2
-from subprocess import Popen, PIPE
 
 applescript = '''if application "Spotify" is running and application "Podcasts" is not running then
 	tell application "Spotify"
@@ -20,7 +21,8 @@ applescript = '''if application "Spotify" is running and application "Podcasts" 
 				set state to "paused"
 			end if
 
-			set display to state & ";" & track_name & ";" & track_artist & ";" & (round ((seconds_played * 1000 / track_duration) * 100))
+			set display to state & ";" & track_name & ";" & track_artist & ";" & ¬
+				(round ((seconds_played * 1000 / track_duration) * 100))
 		end if
 	end tell
 else
@@ -60,14 +62,14 @@ async def main(connection):
     @iterm2.StatusBarRPC
     async def coro(knobs):
         if vl in knobs and knobs[vl]:
-            l = check_spotify()
-            if l[0] == "closed":
+            track = check_spotify()
+            if track[0] == "closed":
                 return [ "✖️ Spotify Closed", "✖️" ]
             else:
-                return [ "{0} {1} - {2} ({3}%)".format(*l),
-                        "{0} {1} ({3}%)".format(*l),
-                        "{0} {1}".format(*l),
-                        "{0}".format(*l)
+                return [ "{} {} - {} ({}%)".format(*track),
+                        "{0} {1} ({3}%)".format(*track),
+                        "{} {}".format(*track),
+                        "{}".format(*track)
                 ]
         return "✖️ Not Enabled"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.pytest.ini_options]
+pythonpath = "."
+
+[tool.coverage.run]
+# now-playing.py is loaded by path (see tests/test_now_playing.py), not
+# `import`ed under a dotted name, so pytest-cov's module-name-based --cov
+# lookup can't find it; --cov=. (directory/path tracking) is used instead,
+# with everything except the script itself omitted from the report.
+omit = ["tests/*", ".venv/*"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov

--- a/tests/test_now_playing.py
+++ b/tests/test_now_playing.py
@@ -1,0 +1,83 @@
+"""Tests for now-playing.py.
+
+Only `check_spotify()` is covered here: it is the one piece of synchronous,
+`iterm2`-free logic in the script, and it's exercised by mocking
+`subprocess.Popen` so no real `osascript`/Spotify call ever happens.
+
+Deliberately NOT covered: `main()`, the `coro` status-bar callback, and the
+`iterm2.StatusBarComponent`/`iterm2.run_forever` registration wiring. Those
+only make sense inside iTerm2's bundled Python Runtime talking to a real
+iTerm2 process, which isn't something a unit test in CI can meaningfully
+exercise -- see AGENTS.md.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "now-playing.py"
+
+
+def _load_now_playing():
+    """Load now-playing.py by path, stubbing out the real `iterm2` package.
+
+    The real `iterm2` module only exists inside iTerm2's bundled Python
+    Runtime, and the script imports it unconditionally at module level, so a
+    fake module must be registered in `sys.modules` before the file is
+    loaded.
+    """
+    fake_iterm2 = types.ModuleType("iterm2")
+    fake_iterm2.CheckboxKnob = MagicMock()
+    fake_iterm2.StatusBarComponent = MagicMock()
+    fake_iterm2.StatusBarRPC = lambda func: func
+    fake_iterm2.run_forever = MagicMock()
+    sys.modules["iterm2"] = fake_iterm2
+
+    spec = importlib.util.spec_from_file_location("now_playing", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+now_playing = _load_now_playing()
+
+
+def _mock_popen(stdout: bytes, returncode: int = 0):
+    process = MagicMock()
+    process.communicate.return_value = (stdout, b"")
+    process.returncode = returncode
+    return process
+
+
+def test_check_spotify_playing():
+    stdout = b"playing;Black Betty;Spiderbait;4\n"
+    with patch.object(now_playing, "Popen", return_value=_mock_popen(stdout)):
+        result = now_playing.check_spotify()
+
+    assert result == ["♬", "Black Betty", "Spiderbait", "4"]
+
+
+def test_check_spotify_paused():
+    stdout = b"paused;Black Betty;Spiderbait;4\n"
+    with patch.object(now_playing, "Popen", return_value=_mock_popen(stdout)):
+        result = now_playing.check_spotify()
+
+    assert result == ["☉", "Black Betty", "Spiderbait", "4"]
+
+
+def test_check_spotify_closed():
+    with patch.object(now_playing, "Popen", return_value=_mock_popen(b"closed;;;\n")):
+        result = now_playing.check_spotify()
+
+    assert result == ["closed", "", "", ""]
+
+
+def test_check_spotify_error_on_nonzero_returncode():
+    with patch.object(
+        now_playing, "Popen", return_value=_mock_popen(b"", returncode=1)
+    ):
+        result = now_playing.check_spotify()
+
+    assert result == "error"


### PR DESCRIPTION
## Summary
- Add ruff + markdownlint CI workflows and dependabot config, mirroring `jackrayner/miele-outlet-scrape`
- Add a small pytest suite for `check_spotify()`, mocking `subprocess.Popen` and stubbing the `iterm2` module (which only exists inside iTerm2's bundled Python Runtime and can't be pip-installed)
- Add `AGENTS.md`/`CLAUDE.md`/`CONTRIBUTING.md` and restructure `README.md` with CI/license badges, adapted to this project's constraints (no PEP 723 inline deps, no `requirements.txt` for `iterm2`, macOS-only test runner)
- Minor ruff-driven cleanup in `now-playing.py` (import order, ambiguous variable name, one long AppleScript line split), behavior verified unchanged via a manual `osascript` run

## Test plan
- [x] `ruff check .` passes
- [x] `python3 -m pytest` passes (4 tests)
- [x] CI runs green on this PR (workflows target `main`, which is now the default branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)