### PR TITLE
Add install.sh for one-line installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ Tests cover `check_spotify()` by mocking `subprocess.Popen`. Manual
 end-to-end testing of the status-bar component itself (the `iterm2`
 registration, live formatting, refresh cadence, etc.) requires an actual
 iTerm2 + Spotify installation, since the `iterm2` runtime and Spotify's
-AppleScript integration can't be exercised in CI. To test manually, symlink
-the script into iTerm2's AutoLaunch folder as described in the README and
-restart iTerm2.
+AppleScript integration can't be exercised in CI. To test manually, run `./install.sh`
+from your clone (it symlinks the script into iTerm2's AutoLaunch folder so
+local edits take effect immediately) and restart iTerm2.
 
 ## Linting
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,19 @@ _Enables Spotify track information in the iTerm2 status bar._
 ## Installation
 
 ```sh
+curl -fsSL https://raw.githubusercontent.com/jackrayner/iterm2-spotify-nowplaying/main/install.sh | sh
+```
+
+Then restart iTerm2 to load the script.
+
+If you'd rather review the script first, or you're working from a clone
+(e.g. for development), run it locally instead -- it'll symlink
+`now-playing.py` so `git pull` keeps it up to date:
+
+```sh
 git clone https://github.com/jackrayner/iterm2-spotify-nowplaying.git
 cd iterm2-spotify-nowplaying
-mkdir -p ~/Library/Application\ Support/iTerm2/Scripts/AutoLaunch
-ln -s "${PWD}/now-playing.py" ~/Library/Application\ Support/iTerm2/Scripts/AutoLaunch/now-playing.py
+./install.sh
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ _Enables Spotify track information in the iTerm2 status bar._
 ## Installation
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/jackrayner/iterm2-spotify-nowplaying/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/jackrayner/iterm2-spotify-nowplaying/main/install.sh | bash
 ```
 
 Then restart iTerm2 to load the script.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Installs now-playing.py into iTerm2's AutoLaunch folder.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/jackrayner/iterm2-spotify-nowplaying/main/install.sh | sh
+# or, from a clone of this repo:
+#   ./install.sh
+set -eu
+
+RAW_URL="https://raw.githubusercontent.com/jackrayner/iterm2-spotify-nowplaying/main/now-playing.py"
+AUTOLAUNCH_DIR="$HOME/Library/Application Support/iTerm2/Scripts/AutoLaunch"
+TARGET="$AUTOLAUNCH_DIR/now-playing.py"
+
+mkdir -p "$AUTOLAUNCH_DIR"
+
+# $0 only points at a real now-playing.py when this script is run from a
+# clone (e.g. `./install.sh`); under `curl | sh` it's just "sh", so this
+# falls through to downloading the file directly.
+if [ -f "$0" ] && [ -f "$(dirname -- "$0")/now-playing.py" ]; then
+    SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+    ln -sf "$SCRIPT_DIR/now-playing.py" "$TARGET"
+    echo "Symlinked $SCRIPT_DIR/now-playing.py -> $TARGET"
+else
+    curl -fsSL "$RAW_URL" -o "$TARGET"
+    echo "Installed now-playing.py -> $TARGET"
+fi
+
+echo "Restart iTerm2 to load the script."

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Installs now-playing.py into iTerm2's AutoLaunch folder.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/jackrayner/iterm2-spotify-nowplaying/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/jackrayner/iterm2-spotify-nowplaying/main/install.sh | bash
 # or, from a clone of this repo:
 #   ./install.sh
-set -eu
+set -euo pipefail
 
 RAW_URL="https://raw.githubusercontent.com/jackrayner/iterm2-spotify-nowplaying/main/now-playing.py"
 AUTOLAUNCH_DIR="$HOME/Library/Application Support/iTerm2/Scripts/AutoLaunch"
@@ -14,7 +14,7 @@ TARGET="$AUTOLAUNCH_DIR/now-playing.py"
 mkdir -p "$AUTOLAUNCH_DIR"
 
 # $0 only points at a real now-playing.py when this script is run from a
-# clone (e.g. `./install.sh`); under `curl | sh` it's just "sh", so this
+# clone (e.g. `./install.sh`); under `curl | bash` it's just "bash", so this
 # falls through to downloading the file directly.
 if [ -f "$0" ] && [ -f "$(dirname -- "$0")/now-playing.py" ]; then
     SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -1,0 +1,137 @@
+"""Tests for install.sh.
+
+Runs the real script under `bash` (subprocess) against a fake `$HOME`, so
+nothing here touches the developer's actual iTerm2 AutoLaunch folder.
+
+The "piped via `curl | bash`" mode is exercised by feeding the script to
+`bash` over stdin (so `$0` is `bash`, just like the real curl pipeline) while
+skipping the real network call: a stub `curl` executable is put first on
+`PATH`, the same way the other test module stubs out `iterm2` -- see
+AGENTS.md on why real external dependencies aren't exercised in CI.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "install.sh"
+AUTOLAUNCH_SUFFIX = Path("Library/Application Support/iTerm2/Scripts/AutoLaunch")
+
+CURL_STUB = """\
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -o) out="$2"; shift 2 ;;
+        -*) shift ;;
+        *) url="$1"; shift ;;
+    esac
+done
+echo "$url" >> "$CURL_LOG"
+echo "stub-download-content" > "$out"
+"""
+
+
+@pytest.fixture
+def fake_home(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    return home
+
+
+def _autolaunch_target(home: Path) -> Path:
+    return home / AUTOLAUNCH_SUFFIX / "now-playing.py"
+
+
+def test_symlinks_now_playing_when_run_from_a_clone(fake_home):
+    clone = fake_home.parent / "clone"
+    clone.mkdir()
+    shutil.copy(SCRIPT_PATH, clone / "install.sh")
+    now_playing = clone / "now-playing.py"
+    now_playing.write_text("# real script contents\n")
+
+    subprocess.run(
+        ["bash", "install.sh"],
+        cwd=clone,
+        env={"HOME": str(fake_home), "PATH": "/usr/bin:/bin"},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    target = _autolaunch_target(fake_home)
+    assert target.is_symlink()
+    assert target.resolve() == now_playing.resolve()
+
+
+def test_rerunning_from_a_clone_is_idempotent(fake_home):
+    clone = fake_home.parent / "clone"
+    clone.mkdir()
+    shutil.copy(SCRIPT_PATH, clone / "install.sh")
+    (clone / "now-playing.py").write_text("# real script contents\n")
+
+    for _ in range(2):
+        subprocess.run(
+            ["bash", "install.sh"],
+            cwd=clone,
+            env={"HOME": str(fake_home), "PATH": "/usr/bin:/bin"},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    target = _autolaunch_target(fake_home)
+    assert target.is_symlink()
+
+
+def test_downloads_now_playing_when_piped_without_a_clone(fake_home, tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    curl_log = tmp_path / "curl.log"
+    curl_stub = bin_dir / "curl"
+    curl_stub.write_text(CURL_STUB)
+    curl_stub.chmod(0o755)
+
+    with SCRIPT_PATH.open() as script:
+        result = subprocess.run(
+            ["bash"],
+            stdin=script,
+            env={
+                "HOME": str(fake_home),
+                "PATH": f"{bin_dir}:/usr/bin:/bin",
+                "CURL_LOG": str(curl_log),
+            },
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    target = _autolaunch_target(fake_home)
+    assert not target.is_symlink()
+    assert target.read_text() == "stub-download-content\n"
+    assert "now-playing.py" in curl_log.read_text()
+    assert "Installed now-playing.py" in result.stdout
+
+
+def test_creates_autolaunch_directory_if_missing(fake_home):
+    assert not (fake_home / AUTOLAUNCH_SUFFIX).exists()
+
+    clone = fake_home.parent / "clone"
+    clone.mkdir()
+    shutil.copy(SCRIPT_PATH, clone / "install.sh")
+    (clone / "now-playing.py").write_text("# real script contents\n")
+
+    subprocess.run(
+        ["bash", "install.sh"],
+        cwd=clone,
+        env={"HOME": str(fake_home), "PATH": "/usr/bin:/bin"},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert (fake_home / AUTOLAUNCH_SUFFIX).is_dir()


### PR DESCRIPTION
## Summary
- Add `install.sh`: symlinks `now-playing.py` into iTerm2's AutoLaunch folder when run from a clone, or downloads it directly when piped via `curl | sh`
- Update README with the one-line curl install as the primary method, keeping clone + `./install.sh` as the review-it-first / dev alternative
- Update CONTRIBUTING.md's manual E2E testing instructions to use `./install.sh`

## Test plan
- [x] Ran `./install.sh` from the repo with a fake `$HOME` — confirmed it symlinks `now-playing.py` correctly
- [x] Piped the script contents via `sh` with a fake `$HOME` — confirmed it downloads `now-playing.py` from GitHub correctly
- [ ] Restart iTerm2 after installing via both paths and confirm the status bar component still loads