### PR TITLE
Fix crashes in check_spotify() edge cases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,11 +52,18 @@ ruff check .
   stubs it out in `sys.modules` before loading the script (see
   `tests/test_now_playing.py`). Never add `iterm2` to a requirements file.
 - The AppleScript in `applescript` is fragile, string-templated shell
-  content that emits semicolon-delimited fields (`state;name;artist;percent`
-  or `closed;;;`). If you change its output shape, you must update
-  `check_spotify()`'s parsing (the `.split(";")` and index-based lookups)
-  and the `coro` formatting strings (`"{0} {1} - {2} ({3}%)"` etc.) in the
-  same change, or the status bar will silently show garbage.
+  content that emits four fields delimited by `\x1e` (ASCII record
+  separator, chosen because it can't appear in Spotify track/artist
+  metadata -- a literal `;` in a track name used to corrupt parsing when
+  `;` was the delimiter). The first field is one of `playing`, `paused`,
+  `stopped` (Spotify running with no track loaded), `closed` (Spotify not
+  running, or Podcasts is running), or `error` (non-zero `osascript` exit,
+  synthesized by `check_spotify()` itself rather than the AppleScript). If
+  you change the output shape, you must update `check_spotify()`'s parsing
+  (the `.split("\x1e")` and index-based lookups), the `coro`
+  `status_messages` dict, and the `coro` formatting strings
+  (`"{0} {1} - {2} ({3}%)"` etc.) in the same change, or the status bar will
+  silently show garbage or raise an `IndexError`.
 - `check_spotify()` is the only synchronous, `iterm2`-independent logic, and
   therefore the only thing unit-tested. `main()`/`coro`/the
   `iterm2.StatusBarComponent` registration require a real iTerm2 process and

--- a/now-playing.py
+++ b/now-playing.py
@@ -7,10 +7,11 @@ from subprocess import PIPE, Popen
 
 import iterm2
 
-applescript = '''if application "Spotify" is running and application "Podcasts" is not running then
+applescript = '''set fs to ASCII character 30
+if application "Spotify" is running and application "Podcasts" is not running then
 	tell application "Spotify"
 		if player state is stopped then
-			set display to "No Track Playing"
+			set display to "stopped" & fs & fs & fs
 		else
 			set track_artist to artist of current track
 			set track_name to name of current track
@@ -21,26 +22,29 @@ applescript = '''if application "Spotify" is running and application "Podcasts" 
 				set state to "paused"
 			end if
 
-			set display to state & ";" & track_name & ";" & track_artist & ";" & ¬
+			set display to state & fs & track_name & fs & track_artist & fs & ¬
 				(round ((seconds_played * 1000 / track_duration) * 100))
 		end if
 	end tell
 else
-	set display to "closed;;;"
+	set display to "closed" & fs & fs & fs
 end if'''
 
 def check_spotify():
     p = Popen(['osascript', '-'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate(applescript.encode('utf-8'))
-    if p.returncode == 0:
-        output = stdout.decode('utf-8').strip().split(";")
-        if output[0] == "playing":
-            output[0] = "♬"
-        elif output[0] == "paused":
-            output[0] = "☉"
-        return output
-    else:
-        return "error"
+    if p.returncode != 0:
+        return ["error", "", "", "0"]
+
+    # Only strip the trailing newline: `\x1e` is classified as whitespace by
+    # str.isspace(), so a bare .strip() would also eat empty leading/trailing
+    # fields (e.g. the "closed"/"stopped" cases).
+    output = stdout.decode('utf-8').rstrip("\n").split("\x1e")
+    if output[0] == "playing":
+        output[0] = "♬"
+    elif output[0] == "paused":
+        output[0] = "☉"
+    return output
 
 async def main(connection):
     # Define the configuration knobs:
@@ -59,12 +63,18 @@ async def main(connection):
     # References specify paths to external variables (like rows) and binds them to
     # arguments to the registered function (coro). When any of those variables' values
     # change the function gets called.
+    status_messages = {
+        "closed": "Spotify Closed",
+        "stopped": "No Track Playing",
+        "error": "Error",
+    }
+
     @iterm2.StatusBarRPC
     async def coro(knobs):
         if vl in knobs and knobs[vl]:
             track = check_spotify()
-            if track[0] == "closed":
-                return [ "✖️ Spotify Closed", "✖️" ]
+            if track[0] in status_messages:
+                return [ f"✖️ {status_messages[track[0]]}", "✖️" ]
             else:
                 return [ "{} {} - {} ({}%)".format(*track),
                         "{0} {1} ({3}%)".format(*track),

--- a/tests/test_now_playing.py
+++ b/tests/test_now_playing.py
@@ -52,7 +52,7 @@ def _mock_popen(stdout: bytes, returncode: int = 0):
 
 
 def test_check_spotify_playing():
-    stdout = b"playing;Black Betty;Spiderbait;4\n"
+    stdout = b"playing\x1eBlack Betty\x1eSpiderbait\x1e4\n"
     with patch.object(now_playing, "Popen", return_value=_mock_popen(stdout)):
         result = now_playing.check_spotify()
 
@@ -60,7 +60,7 @@ def test_check_spotify_playing():
 
 
 def test_check_spotify_paused():
-    stdout = b"paused;Black Betty;Spiderbait;4\n"
+    stdout = b"paused\x1eBlack Betty\x1eSpiderbait\x1e4\n"
     with patch.object(now_playing, "Popen", return_value=_mock_popen(stdout)):
         result = now_playing.check_spotify()
 
@@ -68,10 +68,20 @@ def test_check_spotify_paused():
 
 
 def test_check_spotify_closed():
-    with patch.object(now_playing, "Popen", return_value=_mock_popen(b"closed;;;\n")):
+    stdout = b"closed\x1e\x1e\x1e\n"
+    with patch.object(now_playing, "Popen", return_value=_mock_popen(stdout)):
         result = now_playing.check_spotify()
 
     assert result == ["closed", "", "", ""]
+
+
+def test_check_spotify_stopped():
+    """Spotify is running but has no track loaded (e.g. never played anything)."""
+    stdout = b"stopped\x1e\x1e\x1e\n"
+    with patch.object(now_playing, "Popen", return_value=_mock_popen(stdout)):
+        result = now_playing.check_spotify()
+
+    assert result == ["stopped", "", "", ""]
 
 
 def test_check_spotify_error_on_nonzero_returncode():
@@ -80,4 +90,17 @@ def test_check_spotify_error_on_nonzero_returncode():
     ):
         result = now_playing.check_spotify()
 
-    assert result == "error"
+    assert result == ["error", "", "", "0"]
+
+
+def test_check_spotify_track_name_containing_semicolon():
+    """A literal ';' in a track/artist name must not corrupt field parsing.
+
+    The old ';'-delimited format broke on this; the record-separator
+    delimiter (0x1e) can't appear in Spotify metadata.
+    """
+    stdout = b"playing\x1eRock; Roll\x1eArtist\x1e50\n"
+    with patch.object(now_playing, "Popen", return_value=_mock_popen(stdout)):
+        result = now_playing.check_spotify()
+
+    assert result == ["♬", "Rock; Roll", "Artist", "50"]


### PR DESCRIPTION
## Summary
- Fix a crash (`IndexError`) when Spotify is running but has no track loaded — the AppleScript's "stopped" player state produced a 1-element list that broke `coro`'s positional `.format(*track)` calls.
- Fix `check_spotify()`'s error path returning a bare string (`"error"`) instead of a list shaped like every other return path, which silently rendered garbled characters in the status bar instead of an error indicator.
- Switch the field delimiter from `;` to the ASCII record separator (`\x1e`), since a literal `;` in a track/artist name would corrupt field parsing under the old scheme.
- Along the way, discovered and fixed that `\x1e` is classified as whitespace by Python's `str.isspace()`, so the existing `.strip()` call was silently eating the delimiter itself on empty-field cases (`closed`/`stopped`) — switched to `.rstrip("\n")`.

## Test plan
- [x] `ruff check .` passes
- [x] `python3 -m pytest` passes (6 tests, added 2: `stopped` state, semicolon-in-track-name)
- [x] Manually verified the AppleScript syntax (`ASCII character 30`, `¬` continuation) via a direct `osascript` run
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)