### PR TITLE
Offer to enable iTerm2's Python API in install.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,12 @@ ruff check .
   template string sent to `osascript`), `check_spotify()` (runs it and
   parses the result), and `main()`/`coro` (the `iterm2` status-bar
   registration and formatting logic).
+- `install.sh` -- installs `now-playing.py` into iTerm2's AutoLaunch
+  folder (symlinking it when run from a clone, downloading it otherwise)
+  and offers to enable iTerm2's Python API if it's off.
 - `tests/test_now_playing.py` -- unit tests for `check_spotify()` only.
+- `tests/test_install_sh.py` -- runs `install.sh` under `bash` against a
+  fake `$HOME`, with `curl`/`defaults` stubbed out on `PATH`.
 - `img/` -- screenshots used in README.md.
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ _Enables Spotify track information in the iTerm2 status bar._
 curl -fsSL https://raw.githubusercontent.com/jackrayner/iterm2-spotify-nowplaying/main/install.sh | bash
 ```
 
-Then restart iTerm2 to load the script.
+If iTerm2's Python API is disabled, the script will offer to enable it for
+you (it's required for `now-playing.py` to run at all). Then restart iTerm2
+to load the script.
 
 If you'd rather review the script first, or you're working from a clone
 (e.g. for development), run it locally instead -- it'll symlink

--- a/install.sh
+++ b/install.sh
@@ -25,4 +25,38 @@ else
     echo "Installed now-playing.py -> $TARGET"
 fi
 
+API_SERVER_DOMAIN="com.googlecode.iterm2"
+API_SERVER_KEY="EnableAPIServer"
+
+print_enable_api_hint() {
+    echo "Enable it in iTerm2 Preferences > General > Magic, or run:"
+    echo "  defaults write $API_SERVER_DOMAIN $API_SERVER_KEY -bool true"
+}
+
+api_enabled=$(defaults read "$API_SERVER_DOMAIN" "$API_SERVER_KEY" 2>/dev/null || echo "0")
+
+if [ "$api_enabled" = "1" ]; then
+    echo "iTerm2's Python API is already enabled."
+elif { exec 3<>/dev/tty; } 2>/dev/null; then
+    # now-playing.py needs iTerm2's Python API to run at all, but it's off
+    # by default; /dev/tty lets this prompt work even when this script is
+    # itself being fed to bash over stdin (curl | bash).
+    printf "iTerm2's Python API is disabled, but is required for this script to run. Enable it now? [y/N] " >&3
+    read -r reply <&3
+    exec 3<&-
+    case "$reply" in
+        [Yy]*)
+            defaults write "$API_SERVER_DOMAIN" "$API_SERVER_KEY" -bool true
+            echo "Enabled iTerm2's Python API."
+            ;;
+        *)
+            echo "Skipped enabling iTerm2's Python API."
+            print_enable_api_hint
+            ;;
+    esac
+else
+    echo "iTerm2's Python API is disabled and no terminal is available to prompt."
+    print_enable_api_hint
+fi
+
 echo "Restart iTerm2 to load the script."

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -4,14 +4,26 @@ Runs the real script under `bash` (subprocess) against a fake `$HOME`, so
 nothing here touches the developer's actual iTerm2 AutoLaunch folder.
 
 The "piped via `curl | bash`" mode is exercised by feeding the script to
-`bash` over stdin (so `$0` is `bash`, just like the real curl pipeline) while
-skipping the real network call: a stub `curl` executable is put first on
-`PATH`, the same way the other test module stubs out `iterm2` -- see
-AGENTS.md on why real external dependencies aren't exercised in CI.
+`bash` over stdin (so `$0` is `bash`, just like the real curl pipeline).
+Real external commands (`curl`, `defaults`) are replaced with stub
+executables put first on `PATH`, the same way the other test module stubs
+out `iterm2` -- see AGENTS.md on why real external dependencies aren't
+exercised in CI. Stubbing `defaults` also means these tests never read or
+write the developer's actual `com.googlecode.iterm2` preferences.
+
+The "confirm the Python API prompt" tests attach the script's stdin/stdout
+to a pty: install.sh reads the prompt answer from `/dev/tty` specifically
+so the prompt still works when the script itself is piped into `bash` over
+stdin, and a plain pipe/devnull stdin can't stand in for a controlling
+terminal.
 """
 
+import os
+import pty
+import select
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -35,6 +47,16 @@ echo "$url" >> "$CURL_LOG"
 echo "stub-download-content" > "$out"
 """
 
+DEFAULTS_STUB = """\
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$@" >> "$DEFAULTS_LOG"
+if [ "$1" = "read" ]; then
+    echo "${DEFAULTS_READ_VALUE:-0}"
+    exit "${DEFAULTS_READ_EXIT:-1}"
+fi
+"""
+
 
 @pytest.fixture
 def fake_home(tmp_path):
@@ -43,21 +65,46 @@ def fake_home(tmp_path):
     return home
 
 
+@pytest.fixture
+def stub_bin(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name, contents in (("curl", CURL_STUB), ("defaults", DEFAULTS_STUB)):
+        stub = bin_dir / name
+        stub.write_text(contents)
+        stub.chmod(0o755)
+    return bin_dir
+
+
+@pytest.fixture
+def clone(fake_home):
+    clone_dir = fake_home.parent / "clone"
+    clone_dir.mkdir()
+    shutil.copy(SCRIPT_PATH, clone_dir / "install.sh")
+    (clone_dir / "now-playing.py").write_text("# real script contents\n")
+    return clone_dir
+
+
 def _autolaunch_target(home: Path) -> Path:
     return home / AUTOLAUNCH_SUFFIX / "now-playing.py"
 
 
-def test_symlinks_now_playing_when_run_from_a_clone(fake_home):
-    clone = fake_home.parent / "clone"
-    clone.mkdir()
-    shutil.copy(SCRIPT_PATH, clone / "install.sh")
-    now_playing = clone / "now-playing.py"
-    now_playing.write_text("# real script contents\n")
+def _base_env(fake_home, stub_bin, tmp_path, *, api_enabled):
+    return {
+        "HOME": str(fake_home),
+        "PATH": f"{stub_bin}:/usr/bin:/bin",
+        "CURL_LOG": str(tmp_path / "curl.log"),
+        "DEFAULTS_LOG": str(tmp_path / "defaults.log"),
+        "DEFAULTS_READ_VALUE": "1" if api_enabled else "0",
+        "DEFAULTS_READ_EXIT": "0" if api_enabled else "1",
+    }
 
+
+def test_symlinks_now_playing_when_run_from_a_clone(fake_home, stub_bin, clone, tmp_path):
     subprocess.run(
         ["bash", "install.sh"],
         cwd=clone,
-        env={"HOME": str(fake_home), "PATH": "/usr/bin:/bin"},
+        env=_base_env(fake_home, stub_bin, tmp_path, api_enabled=True),
         check=True,
         capture_output=True,
         text=True,
@@ -65,46 +112,32 @@ def test_symlinks_now_playing_when_run_from_a_clone(fake_home):
 
     target = _autolaunch_target(fake_home)
     assert target.is_symlink()
-    assert target.resolve() == now_playing.resolve()
+    assert target.resolve() == (clone / "now-playing.py").resolve()
 
 
-def test_rerunning_from_a_clone_is_idempotent(fake_home):
-    clone = fake_home.parent / "clone"
-    clone.mkdir()
-    shutil.copy(SCRIPT_PATH, clone / "install.sh")
-    (clone / "now-playing.py").write_text("# real script contents\n")
-
+def test_rerunning_from_a_clone_is_idempotent(fake_home, stub_bin, clone, tmp_path):
+    env = _base_env(fake_home, stub_bin, tmp_path, api_enabled=True)
     for _ in range(2):
         subprocess.run(
             ["bash", "install.sh"],
             cwd=clone,
-            env={"HOME": str(fake_home), "PATH": "/usr/bin:/bin"},
+            env=env,
             check=True,
             capture_output=True,
             text=True,
         )
 
-    target = _autolaunch_target(fake_home)
-    assert target.is_symlink()
+    assert _autolaunch_target(fake_home).is_symlink()
 
 
-def test_downloads_now_playing_when_piped_without_a_clone(fake_home, tmp_path):
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    curl_log = tmp_path / "curl.log"
-    curl_stub = bin_dir / "curl"
-    curl_stub.write_text(CURL_STUB)
-    curl_stub.chmod(0o755)
+def test_downloads_now_playing_when_piped_without_a_clone(fake_home, stub_bin, tmp_path):
+    env = _base_env(fake_home, stub_bin, tmp_path, api_enabled=True)
 
     with SCRIPT_PATH.open() as script:
         result = subprocess.run(
             ["bash"],
             stdin=script,
-            env={
-                "HOME": str(fake_home),
-                "PATH": f"{bin_dir}:/usr/bin:/bin",
-                "CURL_LOG": str(curl_log),
-            },
+            env=env,
             check=True,
             capture_output=True,
             text=True,
@@ -113,25 +146,131 @@ def test_downloads_now_playing_when_piped_without_a_clone(fake_home, tmp_path):
     target = _autolaunch_target(fake_home)
     assert not target.is_symlink()
     assert target.read_text() == "stub-download-content\n"
-    assert "now-playing.py" in curl_log.read_text()
+    assert "now-playing.py" in Path(env["CURL_LOG"]).read_text()
     assert "Installed now-playing.py" in result.stdout
 
 
-def test_creates_autolaunch_directory_if_missing(fake_home):
+def test_creates_autolaunch_directory_if_missing(fake_home, stub_bin, clone, tmp_path):
     assert not (fake_home / AUTOLAUNCH_SUFFIX).exists()
-
-    clone = fake_home.parent / "clone"
-    clone.mkdir()
-    shutil.copy(SCRIPT_PATH, clone / "install.sh")
-    (clone / "now-playing.py").write_text("# real script contents\n")
 
     subprocess.run(
         ["bash", "install.sh"],
         cwd=clone,
-        env={"HOME": str(fake_home), "PATH": "/usr/bin:/bin"},
+        env=_base_env(fake_home, stub_bin, tmp_path, api_enabled=True),
         check=True,
         capture_output=True,
         text=True,
     )
 
     assert (fake_home / AUTOLAUNCH_SUFFIX).is_dir()
+
+
+def test_skips_prompt_when_api_already_enabled(fake_home, stub_bin, clone, tmp_path):
+    env = _base_env(fake_home, stub_bin, tmp_path, api_enabled=True)
+
+    result = subprocess.run(
+        ["bash", "install.sh"],
+        cwd=clone,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "already enabled" in result.stdout
+    log_lines = Path(env["DEFAULTS_LOG"]).read_text().splitlines()
+    assert log_lines == ["read com.googlecode.iterm2 EnableAPIServer"]
+
+
+def test_prints_hint_and_skips_write_when_no_tty_available(fake_home, stub_bin, clone, tmp_path):
+    env = _base_env(fake_home, stub_bin, tmp_path, api_enabled=False)
+
+    result = subprocess.run(
+        ["bash", "install.sh"],
+        cwd=clone,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "no terminal is available to prompt" in result.stdout
+    assert "defaults write com.googlecode.iterm2 EnableAPIServer -bool true" in result.stdout
+    log_lines = Path(env["DEFAULTS_LOG"]).read_text().splitlines()
+    assert log_lines == ["read com.googlecode.iterm2 EnableAPIServer"]
+
+
+def _run_with_pty_reply(clone, env, reply: str, timeout: float = 5.0) -> str:
+    """Run install.sh with its stdio attached to a pty and feed it `reply`.
+
+    install.sh reads the enable-API prompt from /dev/tty rather than
+    stdin, so a plain pipe can't answer it -- only a real (pseudo)terminal
+    can, which is what this simulates.
+    """
+    master, slave = pty.openpty()
+    try:
+        process = subprocess.Popen(
+            ["bash", "install.sh"],
+            cwd=clone,
+            env=env,
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            start_new_session=True,
+        )
+        os.close(slave)
+        slave = None
+        os.write(master, f"{reply}\n".encode())
+
+        output = b""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline and process.poll() is None:
+            ready, _, _ = select.select([master], [], [], 0.2)
+            if ready:
+                try:
+                    chunk = os.read(master, 4096)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                output += chunk
+
+        process.wait(timeout=timeout)
+        try:
+            while True:
+                chunk = os.read(master, 4096)
+                if not chunk:
+                    break
+                output += chunk
+        except OSError:
+            pass
+        assert process.returncode == 0
+        return output.decode()
+    finally:
+        if slave is not None:
+            os.close(slave)
+        os.close(master)
+
+
+def test_enables_api_server_when_user_confirms_via_tty(fake_home, stub_bin, clone, tmp_path):
+    env = _base_env(fake_home, stub_bin, tmp_path, api_enabled=False)
+
+    output = _run_with_pty_reply(clone, env, "y")
+
+    assert "Enabled iTerm2's Python API." in output
+    log_lines = Path(env["DEFAULTS_LOG"]).read_text().splitlines()
+    assert log_lines == [
+        "read com.googlecode.iterm2 EnableAPIServer",
+        "write com.googlecode.iterm2 EnableAPIServer -bool true",
+    ]
+
+
+def test_skips_write_when_user_declines_via_tty(fake_home, stub_bin, clone, tmp_path):
+    env = _base_env(fake_home, stub_bin, tmp_path, api_enabled=False)
+
+    output = _run_with_pty_reply(clone, env, "n")
+
+    assert "Skipped enabling iTerm2's Python API." in output
+    log_lines = Path(env["DEFAULTS_LOG"]).read_text().splitlines()
+    assert log_lines == ["read com.googlecode.iterm2 EnableAPIServer"]


### PR DESCRIPTION
## Summary
- `now-playing.py` can't run at all unless iTerm2's Python API is enabled (Preferences > General > Magic), and it's off by default
- `install.sh` now checks `defaults read com.googlecode.iterm2 EnableAPIServer` after installing the script, and if it's disabled, prompts (via `/dev/tty`, so it still works when the script is piped into `bash` over stdin) before enabling it with `defaults write`
- If no controlling terminal is available to prompt (e.g. non-interactive contexts), it prints a hint instead of hanging or failing

## Test plan
- [x] Added `tests/test_install_sh.py` coverage for all four states: API already enabled, disabled with no tty available, and disabled with the prompt confirmed/declined over a real pty
- [x] `python3 -m pytest` and `ruff check .` both pass
- [x] Manually verified all four states end-to-end with `defaults`/`curl` stubbed out against a fake `$HOME`