### PR TITLE
Fix scrolling text disappearing when the status bar narrows

### DIFF
--- a/now-playing.py
+++ b/now-playing.py
@@ -112,16 +112,38 @@ async def main(connection):
             return [ f"✖️ {status_messages[track[0]]}", "✖️" ]
 
         icon, name, artist, percent = track
-        title = f"{name} - {artist}"
-        if knobs.get(scroll_key, True) and len(title) > SCROLL_WIDTH:
+        combined = f"{name} - {artist}"
+        scroll_enabled = knobs.get(scroll_key, True)
+        if scroll_enabled:
             state["scroll_offset"] += 1
-            title = scroll_text(title, SCROLL_WIDTH, state["scroll_offset"])
+        offset = state["scroll_offset"]
 
-        return [ f"{icon} {title} ({percent}%)",
-                "{0} {1} ({3}%)".format(*track),
-                "{} {}".format(*track),
-                "{}".format(*track)
+        def scrolled(text, width):
+            if scroll_enabled and len(text) > width:
+                return scroll_text(text, width, offset)
+            return text
+
+        # iTerm2 shows "the longest candidate that fits" the space actually
+        # available. A sparse set of options (as this used to be) leaves gaps
+        # where nothing fits and the component renders blank, so this is a
+        # denser gradient -- and every text-bearing tier uses the scrolling
+        # window (not just the widest one), so scrolling stays visible as the
+        # status bar narrows instead of disappearing along with tier 1.
+        tiers = [
+            (combined, SCROLL_WIDTH, True),
+            (combined, 20, True),
+            (name, 20, True),
+            (name, 12, True),
+            (name, 12, False),
+            (name, 6, False),
         ]
+        candidates = [
+            f"{icon} {scrolled(text, width)} ({percent}%)" if show_percent
+            else f"{icon} {scrolled(text, width)}"
+            for text, width, show_percent in tiers
+        ]
+        candidates.append(icon)
+        return candidates
 
     @iterm2.RPC
     async def on_click(session_id):


### PR DESCRIPTION
## Summary
Follow-up to #6 — the scrolling text worked at full status-bar width but disappeared (blank component) once the window narrowed.

Root cause, per iTerm2's status bar RPC docs ("returns a list of strings then the longest one that fits will be used"):
- The scrolling window was only applied to the widest of the 4 candidate strings, so any narrower tier was static.
- Those 4 candidates were sparse and unevenly spaced (~45 → ~25 → ~20 → 2 chars). A width landing between two of them meant nothing fit, and the component rendered blank instead of falling back further.

## Fix
Replaced the fixed four-tier list with a denser, evenly-graduated set of candidates (38/28/28/20/14/8 chars, down to icon-only), all built through the same scrolling window — matching the pattern used by iTerm2's own "variable-length status bar" example, which uses ~10 graduated options rather than a handful of widely-spaced ones.

## Test plan
- [x] `python3 -m pytest` — 18 passed (unchanged; `coro`/`main` aren't unit-testable per AGENTS.md)
- [x] `ruff check .` — clean
- [x] Manually simulated `coro`'s candidate generation for a long title/artist outside iTerm2 to confirm a smooth width gradient (38 → 8 chars) with scrolling applied at every tier
- [ ] Needs a real iTerm2 restart via `./install.sh` to confirm the blank-at-narrow-width behavior is actually resolved, not just theorized from the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)