### PR TITLE
Speed up scrolling text tick from 1s to 0.2s per character

### DIFF
--- a/now-playing.py
+++ b/now-playing.py
@@ -9,7 +9,7 @@ from subprocess import PIPE, Popen
 import iterm2
 
 DEFAULT_REFRESH_INTERVAL = 5.0
-TICK_SECONDS = 1.0
+TICK_SECONDS = 0.2
 SCROLL_WIDTH = 30
 
 applescript = '''set fs to ASCII character 30


### PR DESCRIPTION
## Summary
- The scrolling marquee advanced 1 character per second (`TICK_SECONDS = 1.0` drives both redraw cadence and `scroll_offset`), which read as "mega slow" in practice.
- Dropped `TICK_SECONDS` to `0.2` (5 chars/sec). This only changes how often the status bar redraws/advances the scroll window -- the actual `osascript` refresh interval is throttled separately via the refresh-interval knob (`spotify_refresh_interval`), so this doesn't add any extra `osascript` calls.

## Test plan
- [x] `python3 -m pytest` — 18 passed
- [x] `ruff check .` — clean
- [ ] Manual E2E via `./install.sh` + iTerm2 restart to confirm scroll speed feels right (not exercisable in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)