### PR TITLE
Speed up scrolling text tick further, from 0.2s to 0.1s per character

### DIFF
--- a/now-playing.py
+++ b/now-playing.py
@@ -9,7 +9,7 @@ from subprocess import PIPE, Popen
 import iterm2
 
 DEFAULT_REFRESH_INTERVAL = 5.0
-TICK_SECONDS = 0.2
+TICK_SECONDS = 0.1
 SCROLL_WIDTH = 30
 
 applescript = '''set fs to ASCII character 30


### PR DESCRIPTION
## Summary
Follow-up to #8 — 5 chars/sec (0.2s tick) still read as "really slow".

- Halved `TICK_SECONDS` again, to `0.1` (10 chars/sec / 100ms per character), roughly the pace typical status-ticker marquees use.
- No documented minimum exists for `update_cadence` in iTerm2's API (it's a bare `float` in the protobuf, no clamp in the Python client) — but it's worth knowing this is a genuinely different mechanism than native components like CPU/memory: those compute in-process with no round trip, while ours is a websocket RPC to the script process on every tick, run continuously whenever the component is enabled (not just while a track is scrolling). Cranking this has a real, small, constant CPU/battery cost.
- If 0.1s doesn't feel meaningfully faster than 0.2s, that'd be good evidence iTerm2 enforces an internal floor below what the API exposes, in which case going lower won't help and isn't worth the overhead — worth reporting back either way.

## Test plan
- [x] `python3 -m pytest` — 18 passed
- [x] `ruff check .` — clean
- [ ] Manual E2E via `./install.sh` + iTerm2 restart to confirm scroll speed (not exercisable in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)