### PR TITLE
Make scroll speed a knob instead of a hardcoded tick interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Enables Spotify track information in the iTerm2 status bar._
   status bar component's settings.
 - Track name, artist and progress (%) information.
 - Long track/artist names scroll to fit the available space (can be
-  disabled in settings).
+  disabled, or its speed tuned, in settings).
 - Click the status bar item to bring Spotify to the front.
 - Playing/Paused indicator.
   - ![Status Bar](/img/playing_full.png "Status Bar")

--- a/now-playing.py
+++ b/now-playing.py
@@ -10,6 +10,7 @@ import iterm2
 
 DEFAULT_REFRESH_INTERVAL = 5.0
 TICK_SECONDS = 0.1
+DEFAULT_SCROLL_SPEED = 0.25
 SCROLL_WIDTH = 30
 
 applescript = '''set fs to ASCII character 30
@@ -66,21 +67,25 @@ async def main(connection):
     vl = "spotify_current_track"
     refresh_key = "spotify_refresh_interval"
     scroll_key = "spotify_scroll_text"
+    scroll_speed_key = "spotify_scroll_speed"
     knobs = [
         iterm2.CheckboxKnob("Enable Spotify Track Info", False, vl),
         iterm2.PositiveFloatingPointKnob(
             "Refresh Interval (seconds)", DEFAULT_REFRESH_INTERVAL, refresh_key),
         iterm2.CheckboxKnob(
             "Scroll long track/artist names", True, scroll_key),
+        iterm2.PositiveFloatingPointKnob(
+            "Scroll Speed (seconds per character)", DEFAULT_SCROLL_SPEED, scroll_speed_key),
     ]
     component = iterm2.StatusBarComponent(
         short_description="Spotify Current Track",
         detailed_description="Displays the currently playing track information from Spotify",
         knobs=knobs,
         exemplar="♬ Black Betty - Spiderbait (4%)",
-        # A fixed, short tick: it drives the visible redraw (so scrolling text
-        # is smooth) but check_spotify() itself is only actually re-run once
-        # per the knob-configurable refresh interval, below.
+        # A fixed, short tick: it's the redraw granularity, not the actual
+        # rate of anything. check_spotify() only re-runs once per the
+        # knob-configurable refresh interval, and the scroll window only
+        # advances once per the knob-configurable scroll speed, both below.
         update_cadence=TICK_SECONDS,
         identifier="com.iterm2.jackrayner.spotify-current-track")
 
@@ -94,7 +99,12 @@ async def main(connection):
         "stopped": "No Track Playing",
         "error": "Error",
     }
-    state = {"track": None, "last_check": 0.0, "scroll_offset": 0}
+    state = {
+        "track": None,
+        "last_check": 0.0,
+        "scroll_offset": 0,
+        "last_scroll_advance": 0.0,
+    }
 
     @iterm2.StatusBarRPC
     async def coro(knobs):
@@ -114,8 +124,10 @@ async def main(connection):
         icon, name, artist, percent = track
         combined = f"{name} - {artist}"
         scroll_enabled = knobs.get(scroll_key, True)
-        if scroll_enabled:
+        scroll_speed = knobs.get(scroll_speed_key, DEFAULT_SCROLL_SPEED)
+        if scroll_enabled and now - state["last_scroll_advance"] >= scroll_speed:
             state["scroll_offset"] += 1
+            state["last_scroll_advance"] = now
         offset = state["scroll_offset"]
 
         def scrolled(text, width):


### PR DESCRIPTION
## Summary
Answers two things from #9's discussion:

1. **"Is pixel scrolling possible?"** No — the status bar RPC only returns plain text strings; iTerm2's renderer owns pixel layout and exposes no offset parameter. Motion is necessarily in whole-character steps.
2. **Given that, stop hardcoding the speed.** The last three PRs (#7-#9) tuned `TICK_SECONDS` (1.0 → 0.2 → 0.1) chasing a speed that felt right, each needing a reinstall+restart to test. This decouples the two concerns:
   - `TICK_SECONDS` stays at `0.1` as pure redraw/check granularity.
   - Scroll advance rate is now its own `PositiveFloatingPointKnob` ("Scroll Speed (seconds per character)", default `0.25`), tunable live from the status bar component's settings in iTerm2 -- no more redeploy-to-test loop.

## Test plan
- [x] `python3 -m pytest` — 18 passed
- [x] `ruff check .` — clean
- [ ] Manual E2E via `./install.sh` + iTerm2 restart: confirm the new "Scroll Speed" knob appears in the component's settings and changes take effect without restarting iTerm2 again

🤖 Generated with [Claude Code](https://claude.com/claude-code)