### PR TITLE
Fix scroll text snapping to a shorter string mid-scroll

### DIFF
--- a/now-playing.py
+++ b/now-playing.py
@@ -136,23 +136,26 @@ async def main(connection):
             return text
 
         # iTerm2 shows "the longest candidate that fits" the space actually
-        # available. A sparse set of options (as this used to be) leaves gaps
-        # where nothing fits and the component renders blank, so this is a
-        # denser gradient -- and every text-bearing tier uses the scrolling
-        # window (not just the widest one), so scrolling stays visible as the
-        # status bar narrows instead of disappearing along with tier 1.
+        # available, measured in rendered (proportional-font) pixel width --
+        # which wobbles slightly from tick to tick purely because the visible
+        # scrolled characters differ, even though the string length doesn't.
+        # Every tier must scroll the *same* underlying text (just narrower
+        # windows of it), or that wobble crossing a tier boundary swaps in a
+        # different, shorter string and looks like a snap/glitch rather than
+        # a smooth narrowing. A sparse set of widths (as this used to be)
+        # also leaves gaps where nothing fits and the component renders
+        # blank, hence the dense gradient here.
         tiers = [
-            (combined, SCROLL_WIDTH, True),
-            (combined, 20, True),
-            (name, 20, True),
-            (name, 12, True),
-            (name, 12, False),
-            (name, 6, False),
+            (SCROLL_WIDTH, True),
+            (20, True),
+            (14, True),
+            (14, False),
+            (8, False),
         ]
         candidates = [
-            f"{icon} {scrolled(text, width)} ({percent}%)" if show_percent
-            else f"{icon} {scrolled(text, width)}"
-            for text, width, show_percent in tiers
+            f"{icon} {scrolled(combined, width)} ({percent}%)" if show_percent
+            else f"{icon} {scrolled(combined, width)}"
+            for width, show_percent in tiers
         ]
         candidates.append(icon)
         return candidates


### PR DESCRIPTION
## Summary
Root cause of the "starts to scroll and then snaps to a shorter string" glitch: the candidate tier list mixed two different text sources — `"name - artist"` for the wider tiers, bare `name` for the narrower ones. iTerm2 picks "the longest candidate that fits" by rendered pixel width (proportional status-bar font), which wobbles slightly tick to tick just from which characters happen to be visible in the scroll window at that instant, even though every candidate's *character count* is constant. When that wobble pushed the widest tier just past the fit threshold for one tick, selection fell through to a `name`-only tier — a shorter, unrelated string — which read as the text randomly snapping shorter mid-scroll, then back.

Fix: every tier now scrolls the *same* `"name - artist"` text, just windowed to a narrower width. A tier-boundary flip now only trims characters off one end instead of swapping in different content, so it should read as a smooth narrowing rather than a glitch.

## Test plan
- [x] `python3 -m pytest` — 18 passed
- [x] `ruff check .` — clean
- [x] Manually simulated `coro`'s candidate generation across several scroll offsets to confirm all tiers stay in sync at the same scroll position
- [ ] Manual E2E via `./install.sh` + iTerm2 restart to confirm the snapping is actually gone in a live status bar (not exercisable in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)