### PR TITLE
Revert scrolling text, back to static field-dropping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,18 @@ Ideas not yet implemented, kept here for reference:
   library" verb, so this needs the Spotify Web API with OAuth and token
   storage -- turning a read-only status widget into an authenticated
   read-write client. A bigger scope change than the rest of this list.
+
+## Already tried and abandoned
+
+- Scrolling/marquee text for long track/artist names. Implemented and
+  iterated on across several PRs, but never rendered reliably: the status
+  bar RPC only returns candidate strings for iTerm2 to pick from ("the
+  longest one that fits"), with no control over pixel-level layout. In a
+  proportional-width font, the rendered width of same-length scrolled
+  substrings wobbles tick to tick, which caused tier selection to flicker
+  (blank renders, snapping to a shorter/different string, right-edge
+  blanking) in ways that were hard to fully diagnose without deeper access
+  to iTerm2's native rendering internals. Reverted in favour of the
+  original static field-dropping degradation (drop artist, then progress,
+  then name). If revisited, it'd need either pixel-stable candidate widths
+  or a different rendering mechanism entirely, not just further tuning.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ _Enables Spotify track information in the iTerm2 status bar._
 
 - Information refresh every 5 seconds by default -- configurable in the
   status bar component's settings.
-- Track name, artist and progress (%) information.
-- Long track/artist names scroll to fit the available space (can be
-  disabled, or its speed tuned, in settings).
+- Track name, artist and progress (%) information, gracefully dropping
+  detail (artist, then progress, then name) as the status bar narrows.
 - Click the status bar item to bring Spotify to the front.
 - Playing/Paused indicator.
   - ![Status Bar](/img/playing_full.png "Status Bar")

--- a/now-playing.py
+++ b/now-playing.py
@@ -9,9 +9,7 @@ from subprocess import PIPE, Popen
 import iterm2
 
 DEFAULT_REFRESH_INTERVAL = 5.0
-TICK_SECONDS = 0.1
-DEFAULT_SCROLL_SPEED = 0.25
-SCROLL_WIDTH = 30
+TICK_SECONDS = 1.0
 
 applescript = '''set fs to ASCII character 30
 if application "Spotify" is running and application "Podcasts" is not running then
@@ -52,30 +50,14 @@ def check_spotify():
         output[0] = "☉"
     return output
 
-def scroll_text(text, width, offset):
-    """Return a `width`-wide window into `text`, wrapping around as `offset` advances."""
-    if len(text) <= width:
-        return text
-    # Pad with a gap so the wrap-around doesn't run the end straight into the start.
-    padded = text + "   "
-    doubled = padded + padded
-    start = offset % len(padded)
-    return doubled[start:start + width]
-
 async def main(connection):
     # Define the configuration knobs:
     vl = "spotify_current_track"
     refresh_key = "spotify_refresh_interval"
-    scroll_key = "spotify_scroll_text"
-    scroll_speed_key = "spotify_scroll_speed"
     knobs = [
         iterm2.CheckboxKnob("Enable Spotify Track Info", False, vl),
         iterm2.PositiveFloatingPointKnob(
             "Refresh Interval (seconds)", DEFAULT_REFRESH_INTERVAL, refresh_key),
-        iterm2.CheckboxKnob(
-            "Scroll long track/artist names", True, scroll_key),
-        iterm2.PositiveFloatingPointKnob(
-            "Scroll Speed (seconds per character)", DEFAULT_SCROLL_SPEED, scroll_speed_key),
     ]
     component = iterm2.StatusBarComponent(
         short_description="Spotify Current Track",
@@ -83,9 +65,8 @@ async def main(connection):
         knobs=knobs,
         exemplar="♬ Black Betty - Spiderbait (4%)",
         # A fixed, short tick: it's the redraw granularity, not the actual
-        # rate of anything. check_spotify() only re-runs once per the
-        # knob-configurable refresh interval, and the scroll window only
-        # advances once per the knob-configurable scroll speed, both below.
+        # refresh rate -- check_spotify() only re-runs once per the
+        # knob-configurable refresh interval, below.
         update_cadence=TICK_SECONDS,
         identifier="com.iterm2.jackrayner.spotify-current-track")
 
@@ -99,12 +80,7 @@ async def main(connection):
         "stopped": "No Track Playing",
         "error": "Error",
     }
-    state = {
-        "track": None,
-        "last_check": 0.0,
-        "scroll_offset": 0,
-        "last_scroll_advance": 0.0,
-    }
+    state = {"track": None, "last_check": 0.0}
 
     @iterm2.StatusBarRPC
     async def coro(knobs):
@@ -121,41 +97,11 @@ async def main(connection):
         if track[0] in status_messages:
             return [ f"✖️ {status_messages[track[0]]}", "✖️" ]
 
-        icon, name, artist, percent = track
-        combined = f"{name} - {artist}"
-        scroll_enabled = knobs.get(scroll_key, True)
-        scroll_speed = knobs.get(scroll_speed_key, DEFAULT_SCROLL_SPEED)
-        if scroll_enabled and now - state["last_scroll_advance"] >= scroll_speed:
-            state["scroll_offset"] += 1
-            state["last_scroll_advance"] = now
-        offset = state["scroll_offset"]
-
-        def scrolled(text, width):
-            if scroll_enabled and len(text) > width:
-                return scroll_text(text, width, offset)
-            return text
-
-        # iTerm2 shows "the longest candidate that fits" the space actually
-        # available. A sparse set of options (as this used to be) leaves gaps
-        # where nothing fits and the component renders blank, so this is a
-        # denser gradient -- and every text-bearing tier uses the scrolling
-        # window (not just the widest one), so scrolling stays visible as the
-        # status bar narrows instead of disappearing along with tier 1.
-        tiers = [
-            (combined, SCROLL_WIDTH, True),
-            (combined, 20, True),
-            (name, 20, True),
-            (name, 12, True),
-            (name, 12, False),
-            (name, 6, False),
+        return [ "{} {} - {} ({}%)".format(*track),
+                "{0} {1} ({3}%)".format(*track),
+                "{} {}".format(*track),
+                "{}".format(*track)
         ]
-        candidates = [
-            f"{icon} {scrolled(text, width)} ({percent}%)" if show_percent
-            else f"{icon} {scrolled(text, width)}"
-            for text, width, show_percent in tiers
-        ]
-        candidates.append(icon)
-        return candidates
 
     @iterm2.RPC
     async def on_click(session_id):

--- a/tests/test_now_playing.py
+++ b/tests/test_now_playing.py
@@ -104,25 +104,3 @@ def test_check_spotify_track_name_containing_semicolon():
         result = now_playing.check_spotify()
 
     assert result == ["♬", "Rock; Roll", "Artist", "50"]
-
-
-def test_scroll_text_returns_input_unchanged_when_it_fits():
-    assert now_playing.scroll_text("Black Betty - Spiderbait", 30, 0) == "Black Betty - Spiderbait"
-
-
-def test_scroll_text_windows_long_text():
-    text = "Bohemian Rhapsody - Queen"
-    assert now_playing.scroll_text(text, 10, 0) == text[:10]
-
-
-def test_scroll_text_advances_with_offset():
-    text = "Bohemian Rhapsody - Queen"
-    assert now_playing.scroll_text(text, 10, 1) == text[1:11]
-
-
-def test_scroll_text_wraps_around():
-    text = "Bohemian Rhapsody - Queen"
-    padded = text + "   "
-    doubled = padded + padded
-    offset = len(padded) + 3
-    assert now_playing.scroll_text(text, 10, offset) == doubled[3:13]


### PR DESCRIPTION
## Summary
Scrolling text never rendered reliably across #6-#11: blank tiers, snapping to a shorter/different string mid-scroll, and now right-edge blanking that persisted even after fixing an offset-reset bug. The common thread is structural, not tunable — the status bar RPC only hands iTerm2 a list of candidate strings ("the longest one that fits"), with no control over pixel-level layout. In a proportional-width status bar font, same-length scrolled substrings' actual rendered width wobbles tick to tick just from which characters are visible, which destabilizes iTerm2's tier selection in ways this script can't fully control from the RPC side.

Reverting to the original static degradation (drop artist → drop progress → drop name → icon-only) rather than continuing to chase a rendering-layer problem with more tuning.

**Kept**: the customisable refresh-interval knob and click-to-open-Spotify — both independent of scrolling and haven't caused any issues.
**Removed**: `scroll_text()`, the scroll/scroll-speed knobs, and all scroll-offset state.
**Added**: a note in `CONTRIBUTING.md`'s "Already tried and abandoned" section so this isn't retried blind.

Closes the now-moot #11.

## Test plan
- [x] `python3 -m pytest` — 14 passed (4 `scroll_text` tests removed along with the function)
- [x] `ruff check .` — clean
- [ ] Manual E2E via iTerm2 restart (the repo's `now-playing.py` is symlinked directly into AutoLaunch, so this just needs a full quit+relaunch of iTerm2) to confirm static field-dropping behaves as before scrolling was introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)